### PR TITLE
feat: add TaskRepository and TagRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ Thumbs.db
 # Credentials (don’t commit sensitive configs!)
 application-*.yml
 application-*.properties
+
+# Ignore the main application.properties file
+src/main/resources/application.properties
+
+# Ignore any environment-specific configs
+src/main/resources/application-*.properties

--- a/src/main/java/com/sareafrica/taskmanagement/repository/TagRepository.java
+++ b/src/main/java/com/sareafrica/taskmanagement/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package com.sareafrica.taskmanagement.repository;
+
+import com.sareafrica.taskmanagement.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    // Example custom query later:
+    // Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/sareafrica/taskmanagement/repository/TaskRepository.java
+++ b/src/main/java/com/sareafrica/taskmanagement/repository/TaskRepository.java
@@ -1,0 +1,11 @@
+package com.sareafrica.taskmanagement.repository;
+
+import com.sareafrica.taskmanagement.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    // Example custom query later:
+    // List<Task> findByStatus(Status status);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
-spring.application.name=taskmanagement
+# PostgreSQL database connection
+spring.datasource.url=jdbc:postgresql://localhost:5432/taskmanagement
+spring.datasource.username=postgres
+spring.datasource.password=password
+
+# JPA / Hibernate settings
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## 📄 Description

This PR introduces repository interfaces for persisting and retrieving data related to Task and Tag entities.
The repositories extend Spring Data JPA’s JpaRepository, which provides CRUD operations out-of-the-box.

## 🛠 Changes Made

- Added TaskRepository interface extending JpaRepository<Task, Long>

- Added TagRepository interface extending JpaRepository<Tag, Long>

- Annotated both with @Repository for Spring to recognize them as beans

## 🔄 Type of Change

- [x] New feature (non-breaking change which adds functionality) 

## ✅ Testing Done

- Application starts successfully without errors

- Tables (tasks, tags, and task_tags) are visible in PostgreSQL
 
- Verified that repositories are detected during Spring Boot startup logs

## ☑️ Checklist

- [x] Code follows project conventions

- [x] Repository interfaces are defined correctly

- [x] Application builds and runs without errors

- [x] Database schema is generated with the expected tables